### PR TITLE
Mistakenly still hadnt properly decoupled the test console

### DIFF
--- a/tests/AppConfigCli.Tests/Commands/_Commands.cs
+++ b/tests/AppConfigCli.Tests/Commands/_Commands.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using AppConfigCli;
+using AppConfigCli.Core;
+using AppConfigCli.Editor.Abstractions;
+
+public partial class _Commands
+{
+    internal static async Task<EditorApp> InstrumentedEditorApp(InMemoryConfigRepository repo, string? label, TestConsoleEx? console = null)
+    {
+        var app = new EditorApp(
+            repo,
+            prefix: "p:",
+            label,
+            () => Task.CompletedTask,
+            new DefaultFileSystem(),
+            new DefaultExternalEditor(),
+            ConsoleTheme.Load(),
+            console ?? new TestConsoleEx());
+
+        await app.LoadAsync();
+        return app;
+    }
+}

--- a/tests/AppConfigCli.Tests/Commands/_Copy.cs
+++ b/tests/AppConfigCli.Tests/Commands/_Copy.cs
@@ -1,34 +1,14 @@
 using System;
-using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using AppConfigCli;
 using AppConfigCli.Core;
-using AppConfigCli.Editor.Abstractions;
 using AppConfigCli.Editor.Commands;
 using FluentAssertions;
 using Xunit;
 
 public partial class _Commands
 {
-    internal static readonly TestConsoleEx consoleEx = new TestConsoleEx();
-
-    internal static async Task<EditorApp> InstrumentedEditorApp(InMemoryConfigRepository repo, string label)
-    {
-        var app = new EditorApp(
-            repo,
-            prefix: "p:",
-            label,
-            () => Task.CompletedTask,
-            new DefaultFileSystem(),
-            new DefaultExternalEditor(),
-            ConsoleTheme.Load(),
-            consoleEx);
-
-        await app.LoadAsync();
-        return app;
-    }
-
     public class _Copy
     {
         private static InMemoryConfigRepository SeedRepo()
@@ -36,16 +16,16 @@ public partial class _Commands
             // Prefix p:, two keys A/B under two labels: original and hidden
             var entries = new[]
             {
-            new ConfigEntry { Key = "p:A", Label = null, Value = "nullA" },
-            new ConfigEntry { Key = "p:B", Label = null, Value = "nullB" },
-            new ConfigEntry { Key = "p:C", Label = null, Value = "nullC" },
-            new ConfigEntry { Key = "p:A", Label = "original", Value = "origA" },
-            new ConfigEntry { Key = "p:B", Label = "original", Value = "origB" },
-            new ConfigEntry { Key = "p:C", Label = "original", Value = "origC" },
-            new ConfigEntry { Key = "p:A", Label = "hidden",   Value = "hidA"  },
-            new ConfigEntry { Key = "p:B", Label = "hidden",   Value = "hidB"  },
-            new ConfigEntry { Key = "p:C", Label = "hidden",   Value = "hidC"  },
-        }.ToList();
+                new ConfigEntry { Key = "p:A", Label = null, Value = "nullA" },
+                new ConfigEntry { Key = "p:B", Label = null, Value = "nullB" },
+                new ConfigEntry { Key = "p:C", Label = null, Value = "nullC" },
+                new ConfigEntry { Key = "p:A", Label = "original", Value = "origA" },
+                new ConfigEntry { Key = "p:B", Label = "original", Value = "origB" },
+                new ConfigEntry { Key = "p:C", Label = "original", Value = "origC" },
+                new ConfigEntry { Key = "p:A", Label = "hidden",   Value = "hidA"  },
+                new ConfigEntry { Key = "p:B", Label = "hidden",   Value = "hidB"  },
+                new ConfigEntry { Key = "p:C", Label = "hidden",   Value = "hidC"  },
+            }.ToList();
 
             return new InMemoryConfigRepository(entries);
         }
@@ -55,7 +35,8 @@ public partial class _Commands
         {
             // Arrange
             var repo = SeedRepo();
-            var app = await InstrumentedEditorApp(repo, "original");
+            var consoleEx = new TestConsoleEx();
+            var app = await InstrumentedEditorApp(repo, "original", consoleEx);
 
             // Sanity: only two visible rows (label: original)
             var visible = app.GetVisibleItems();

--- a/tests/AppConfigCli.Tests/Commands/_Undo.cs
+++ b/tests/AppConfigCli.Tests/Commands/_Undo.cs
@@ -36,7 +36,8 @@ public partial class _Commands
         {
             // Arrange
             var repo = SeedRepo();
-            var app = await InstrumentedEditorApp(repo, "original");
+            var consoleEx = new TestConsoleEx();
+            var app = await InstrumentedEditorApp(repo, "original", consoleEx);
 
             // Sanity: visible rows for label: original
             var visibleBefore = app.GetVisibleItems();

--- a/tests/AppConfigCli.Tests/_IndexMapping.cs
+++ b/tests/AppConfigCli.Tests/_IndexMapping.cs
@@ -13,22 +13,15 @@ public class _IndexMapping
         // Repo not used by MapVisibleRangeToItemIndices; provide a minimal in-memory repo
         var repo = new AppConfigCli.Core.InMemoryConfigRepository(new List<AppConfigCli.Core.ConfigEntry>());
 
-        var app = new EditorApp(
-            repo,
-            prefix: "p:",
-            null,
-            () => Task.CompletedTask,
-            new DefaultFileSystem(),
-            new DefaultExternalEditor(),
-            ConsoleTheme.Load(),
-            new DefaultConsoleEx());
+        var app = _Commands.InstrumentedEditorApp(repo, null).Result;
 
-        app.Test_Items.AddRange(new[]
-        {
+        app.Test_Items.AddRange(
+        [
             new Item { FullKey = "p:Color", ShortKey = "Color", Label = "dev", OriginalValue = "red", Value = "red", State = ItemState.Unchanged },
             new Item { FullKey = "p:Color", ShortKey = "Color", Label = "prod", OriginalValue = "blue", Value = "blue", State = ItemState.Unchanged },
             new Item { FullKey = "p:Title", ShortKey = "Title", Label = null, OriginalValue = "Hello", Value = "Hello", State = ItemState.Unchanged },
-        });
+        ]);
+
         return app;
     }
 


### PR DESCRIPTION
This pull request refactors the test setup code to improve code reuse and consistency across multiple test classes. The main change is the introduction of a shared helper method for creating instrumented instances of `EditorApp`, which replaces duplicated setup logic in several test files.

**Test infrastructure improvements:**

* Added a new static helper method `InstrumentedEditorApp` to the `_Commands` class, which centralizes the logic for creating and initializing an `EditorApp` instance with customizable parameters.
* Updated the `_Copy.cs`, `_Undo.cs`, and `_IndexMapping.cs` test files to use the new `InstrumentedEditorApp` helper method instead of duplicating the setup code, resulting in cleaner and more maintainable test code. [[1]](diffhunk://#diff-53b457187fb49ca876d3bf84b847072fa7e11e9318dbe0c3cd48974204a7e588L2-L31) [[2]](diffhunk://#diff-53b457187fb49ca876d3bf84b847072fa7e11e9318dbe0c3cd48974204a7e588L58-R39) [[3]](diffhunk://#diff-39fc1ed7d79a0724c3a91fbabb5ddb062bd1997c0e0efdee71ccc8999b4d836dL39-R40) [[4]](diffhunk://#diff-5d9175b49c078c251ac942937126dd0aa9f1030250e9fcaf32912f2c30bd616fL16-R24)