### PR TITLE
v1.0

### DIFF
--- a/src/AppConfigCli/Properties/launchSettings.json
+++ b/src/AppConfigCli/Properties/launchSettings.json
@@ -1,11 +1,22 @@
 {
   "profiles": {
-    "AppConfigCli": {
+    "Production": {
       "commandName": "Project",
       "commandLineArgs": "--auth cli",
       "environmentVariables": {
         "APP_CONFIG_ENDPOINT": "https://sh-neu-app-config.azconfig.io"
       }
+    },
+    "Slask": {
+      "commandName": "Project",
+      "commandLineArgs": "--auth cli",
+      "environmentVariables": {
+        "APP_CONFIG_ENDPOINT": "https://sh-app-config-slask.azconfig.io"
+      }
+    },
+    "Choose Enpoint": {
+      "commandName": "Project",
+      "commandLineArgs": "--auth cli"
     }
   }
 }

--- a/tests/AppConfigCli.Tests/_StructuredEditHelper.cs
+++ b/tests/AppConfigCli.Tests/_StructuredEditHelper.cs
@@ -16,6 +16,51 @@ public class _StructuredEditHelper
     }
 
     [Fact]
+    public void build_json_does_not_escape_ascii_in_values()
+    {
+        // Arrange: sample similar to the user-provided example
+        var items = new List<Item>
+        {
+            new Item { FullKey = "MyConfigSection:SampleConnectionString", ShortKey = "MyConfigSection:SampleConnectionString", Label = "prod", OriginalValue = null, Value = "Data Source=database.example.com;Port=12345;Uid=dbuser;Password=my-Super+Secret/pa$$_w0rd#=;charset=utf8", State = ItemState.Unchanged },
+            new Item { FullKey = "MyConfigSection:Test", ShortKey = "MyConfigSection:Test", Label = "prod", OriginalValue = null, Value = "ConnectionString in prod mode. ", State = ItemState.Unchanged },
+            new Item { FullKey = "Settings:BackgroundColor", ShortKey = "Settings:BackgroundColor", Label = "prod", OriginalValue = null, Value = "brown", State = ItemState.Unchanged },
+            new Item { FullKey = "Settings:Message", ShortKey = "Settings:Message", Label = "prod", OriginalValue = null, Value = "Hello in Production override mode !!!!", State = ItemState.Unchanged },
+        };
+
+        // Visible under a single label as required by json editor flow
+        var visible = items.Where(i => i.Label == "prod");
+
+        // Act
+        var json = StructuredEditHelper.BuildJsonContent(visible, ":");
+
+        // Assert: ensure '+' and other ASCII are not unicode-escaped
+        json.Should().Contain("my-Super+Secret/pa$$_w0rd#=");
+        json.Should().NotContain("\\u002B"); // '+'
+        json.Should().NotContain("\\u002F"); // '/'
+        json.Should().NotContain("\\u0023"); // '#'
+
+        // Roundtrip apply should keep the exact value
+        var (ok, err, created, updated, deleted) = StructuredEditHelper.ApplyJsonEdits(json, ":", items, visible, prefix: string.Empty, activeLabel: "prod");
+        ok.Should().BeTrue(err);
+        items.Should().Contain(i => i.FullKey == "MyConfigSection:SampleConnectionString" && i.Label == "prod" && i.Value!.Contains("+Secret/"));
+    }
+
+    [Fact]
+    public void build_json_does_not_escape_ascii_in_property_names()
+    {
+        var items = new List<Item>
+        {
+            new Item { FullKey = "Foo+Bar:Baz", ShortKey = "Foo+Bar:Baz", Label = "prod", OriginalValue = null, Value = "v", State = ItemState.Unchanged }
+        };
+        var visible = items.Where(i => i.Label == "prod");
+        var json = StructuredEditHelper.BuildJsonContent(visible, ":");
+
+        // Property name should appear literally with '+'
+        json.Should().Contain("\"Foo+Bar\"");
+        json.Should().NotContain("\\u002B");
+    }
+
+    [Fact]
     public void apply_json_invalid_top_level_returns_error()
     {
         var items = SeedDev();
@@ -73,5 +118,51 @@ public class _StructuredEditHelper
         items.Should().Contain(i => i.FullKey == "p:NewKey" && i.Label == "dev" && i.State == ItemState.New && i.Value == "val");
         items.Single(i => i.FullKey == "p:Color" && i.Label == "dev").Value.Should().Be("blue");
         items.Single(i => i.FullKey == "p:Title" && i.Label == "dev").State.Should().Be(ItemState.Deleted);
+    }
+
+    [Fact]
+    public void apply_yaml_preserves_ascii_plus_and_slash_in_values()
+    {
+        // Arrange: start with a mismatched value so ApplyYamlEdits updates it
+        var items = new List<Item>
+        {
+            new Item { FullKey = "MyConfigSection:SampleConnectionString", ShortKey = "MyConfigSection:SampleConnectionString", Label = "prod", OriginalValue = null, Value = "WRONG", State = ItemState.Unchanged },
+            new Item { FullKey = "Settings:BackgroundColor", ShortKey = "Settings:BackgroundColor", Label = "prod", OriginalValue = null, Value = "brown", State = ItemState.Unchanged },
+            new Item { FullKey = "Settings:Message", ShortKey = "Settings:Message", Label = "prod", OriginalValue = null, Value = "Hello", State = ItemState.Unchanged },
+        };
+        var visible = items.Where(i => i.Label == "prod");
+
+        var desired = "Data Source=database.example.com;Port=12345;Uid=dbuser;Password=my-Super+Secret/pa$$_w0rd#=;charset=utf8";
+        var yaml =
+            "MyConfigSection:\n" +
+            "  SampleConnectionString: \"" + desired + "\"\n" +
+            "Settings:\n" +
+            "  BackgroundColor: brown\n" +
+            "  Message: Hello in Production override mode !!!!\n";
+
+        // Act
+        var (ok, err, c, u, d) = StructuredEditHelper.ApplyYamlEdits(yaml, ":", items, visible, prefix: string.Empty, activeLabel: "prod");
+
+        // Assert
+        ok.Should().BeTrue(err);
+        u.Should().BeGreaterThan(0);
+        items.Should().Contain(i => i.FullKey == "MyConfigSection:SampleConnectionString" && i.Label == "prod" && i.Value == desired);
+        // Ensure '+' and '/' are present literally in the resulting value
+        items.Single(i => i.FullKey == "MyConfigSection:SampleConnectionString" && i.Label == "prod").Value!.Should().Contain("+Secret/");
+    }
+
+    [Fact]
+    public void apply_yaml_supports_plus_in_property_names()
+    {
+        var items = new List<Item>();
+        var visible = items.Where(i => i.Label == "prod");
+        var yaml =
+            "Foo+Bar:\n" +
+            "  Baz: v\n";
+
+        var (ok, err, c, u, d) = StructuredEditHelper.ApplyYamlEdits(yaml, ":", items, visible, prefix: string.Empty, activeLabel: "prod");
+        ok.Should().BeTrue(err);
+        c.Should().Be(1);
+        items.Should().Contain(i => i.ShortKey == "Foo+Bar:Baz" && i.Value == "v");
     }
 }

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.2",
+  "version": "1.0",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/tags/v\\d+\\.\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
This pull request improves the handling of ASCII characters in JSON and YAML editing workflows, ensuring that characters like `+`, `/`, and `#` are not unnecessarily escaped. It also updates launch profiles for easier environment selection and bumps the project version to 1.0. The most important changes are grouped below:

**JSON and YAML encoding improvements:**

* Updated `StructuredEditHelper.BuildJsonContent` to use a relaxed JSON encoder (`JavaScriptEncoder.UnsafeRelaxedJsonEscaping`), so ASCII characters such as `+`, `/`, and `#` are preserved in both property names and values, making the output more natural for plain-text editing. [[1]](diffhunk://#diff-0d2c3ffd4bf5db09d843d2d76fb6c2f134fa628055c18da692d1cfa3e8e951d4R5) [[2]](diffhunk://#diff-0d2c3ffd4bf5db09d843d2d76fb6c2f134fa628055c18da692d1cfa3e8e951d4L19-R27)
* Added and enhanced tests in `_StructuredEditHelper.cs` to verify that JSON and YAML editors correctly preserve ASCII characters in both property names and values, and that roundtripping edits does not alter these characters. [[1]](diffhunk://#diff-dda317d2bf7d5d67ce8e709ab5dba4e286292958b9d457fad2afae83266c93f8R18-R62) [[2]](diffhunk://#diff-dda317d2bf7d5d67ce8e709ab5dba4e286292958b9d457fad2afae83266c93f8R122-R167)

**Development tooling and configuration:**

* Updated `launchSettings.json` to provide multiple profiles (`Production`, `Slask`, and `Choose Enpoint`), making it easier to select different AppConfig endpoints for local development and testing.

**Versioning:**

* Bumped the project version in `version.json` from `0.2` to `1.0`, indicating a major release milestone.